### PR TITLE
Support Jetpack's related post date

### DIFF
--- a/style.css
+++ b/style.css
@@ -2777,7 +2777,8 @@ div.sharedaddy h3.sd-title:before {
     color: #628d7c;
 }
 
-.entry-content #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-context {
+.entry-content #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-context,
+.entry-content #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-date {
     max-width: 80%;
     text-align: center;
     margin: 0 auto;


### PR DESCRIPTION
Hello!

I hope I'm doing this right ^^U.

I noticed the .jp-relatedposts-post-date field from Jetpack was unstyled. Adding it with the same styles as the context.

Image of the issue at Imagebin: https://ibin.co/39lKnzU2YpN1.png